### PR TITLE
Update main.tf with startup-script fix

### DIFF
--- a/tf-mod2-demo1/main.tf
+++ b/tf-mod2-demo1/main.tf
@@ -78,7 +78,7 @@ resource "google_compute_instance" "tf-mod2-demo1-vm1" {
     }
   } 
   metadata = {
-    startup-script = "sudo apt update; sudo apt install netcat-traditional ncat;"
+    startup-script = "sudo apt update; sudo apt -y install netcat-traditional ncat;"
   }
 
 }


### PR DESCRIPTION
Fix the startup-script of the VM so that the netcat command can be installed as expected.

When I was doing the lab assignment, without the "-y" option the netcat command was not installed.
So I ssh into the VM and manually install it again, I found that apt command stopped execution with a confirmation message saying something like - "Installing this command will spend xxx MB disk space, do you want to continue?", which could be the reason preventing it to be installed automatically.

Later I added the "-y" and tested it with terraform again, this time it was installed successfully.