### PR TITLE
tf-mod1-demo: Add VM boot disk params to stay within the free tier

### DIFF
--- a/tf-mod1-demo/main.tf
+++ b/tf-mod1-demo/main.tf
@@ -23,6 +23,8 @@ resource "google_compute_instance" "mod1-tf-vm1" {
   boot_disk {
     initialize_params {
       image = "debian-12-bookworm-v20240312"
+      size = 30
+      type = "pd-standard"
     }
   } 
   metadata = {


### PR DESCRIPTION
Setting boot disk `size` and `type` (along with running in a supported region) will fit the VM in the free tier and not use up any credit: https://cloud.google.com/free/docs/free-cloud-features#compute